### PR TITLE
Requiring prettier ^1.11.1 as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-nf-prettier",
   "description": "Create vinyl streams to pipe to prettier",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -32,6 +32,6 @@
     "vinyl-sourcemaps-apply": "^0.2.1"
   },
   "peerDependencies": {
-    "prettier": "^0.22.0"
+    "prettier": "^1.11.1"
   }
 }


### PR DESCRIPTION
Updates the module version and sets the peerDependency on prettier to `^1.11.1`